### PR TITLE
Throw an exception instead of passing as a callback parameter

### DIFF
--- a/modules/swagger-codegen/src/main/resources/CsharpUnity/ApiClient.mustache
+++ b/modules/swagger-codegen/src/main/resources/CsharpUnity/ApiClient.mustache
@@ -95,11 +95,14 @@ namespace {{packageName}}.Client
             if (postBody != null) // http body (model) parameter
                 request.AddParameter("application/json", postBody, ParameterType.RequestBody);
 
-            yield return RestClient.Execute(request, success, 
+            yield return RestClient.Execute(request, success,
               (e) =>
               {
-                var apiException = new ApiException(0, "Local Exception:" + e.Message);
-                failure(apiException);
+                try {
+                  throw new ApiException(0, "Local Exception:" + e.Message, e);
+                } catch (ApiException ex) {
+                  failure(ex);
+                }
               });
 
         }

--- a/modules/swagger-codegen/src/main/resources/CsharpUnity/ApiException.mustache
+++ b/modules/swagger-codegen/src/main/resources/CsharpUnity/ApiException.mustache
@@ -41,7 +41,27 @@ namespace {{packageName}}.Client {
           this.ErrorCode = errorCode;
           this.ErrorContent = errorContent;
       }
+      /// <summary>
+      /// Initializes a new instance of the <see cref="ApiException"/> class.
+      /// </summary>
+      /// <param name="errorCode">HTTP status code.</param>
+      /// <param name="message">Error message.</param>
+      /// <param name="ex">Original Exception</param>
+      public ApiException(int errorCode, string message, Exception ex) : base(message, ex) {
+          this.ErrorCode = errorCode;
+      }
 
+      /// <summary>
+      /// Initializes a new instance of the <see cref="ApiException"/> class.
+      /// </summary>
+      /// <param name="errorCode">HTTP status code.</param>
+      /// <param name="message">Error message.</param>
+      /// <param name="errorContent">Error content.</param>
+      /// <param name="ex">Original Exception</param>
+      public ApiException(int errorCode, string message, Object errorContent, Exception ex) : base(message, ex) {
+          this.ErrorCode = errorCode;
+          this.ErrorContent = errorContent;
+      }
   }
 
 }

--- a/modules/swagger-codegen/src/main/resources/CsharpUnity/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/CsharpUnity/api.mustache
@@ -116,13 +116,16 @@ namespace {{packageName}}.Api
             // make the HTTP request
             yield return ApiClient.CallApi(path, Method.{{httpMethod}}, queryParams, postBody, headerParams, formParams, fileParams, authSettings,
                (response) => {
-                 if (((int)response.StatusCode) >= 400)
-                     failure(new ApiException ((int)response.StatusCode, "Error calling {{nickname}}: " + response.Content, response.Content));
-                 else if (((int)response.StatusCode) == 0)
-                     failure(new ApiException ((int)response.StatusCode, "Error calling {{nickname}}: " + response.ErrorMessage, response.ErrorMessage));
-                 else
-                     {{#returnType}}success(({{{returnType}}}) ApiClient.Deserialize(response.Content, typeof({{{returnType}}}), response.Headers));{{/returnType}}{{^returnType}}success();{{/returnType}}
-
+                 try {
+                     if (((int)response.StatusCode) >= 400)
+                         throw new ApiException((int)response.StatusCode, "Error calling {{nickname}}: " + response.Content, response.Content);
+                     else if (((int)response.StatusCode) == 0)
+                         throw new ApiException((int)response.StatusCode, "Error calling {{nickname}}: " + response.ErrorMessage, response.ErrorMessage);
+                     else
+                         {{#returnType}}success(({{{returnType}}}) ApiClient.Deserialize(response.Content, typeof({{{returnType}}}), response.Headers));{{/returnType}}{{^returnType}}success();{{/returnType}}
+                 } catch (ApiException e) {
+                   failure(e);
+                 }
                },
                failure);
 


### PR DESCRIPTION
DotNet runtime fills a stack trace in an Exception object when it is thrown. Unless throwing, it's kept as empty.
Some libraries which refer a stack trace in an Exception causes error when a stack trace is empty.
To avoid causing such errors, an API exception is thrown and caught to fill a stack trace instead of passing as a callback parameter directly.
